### PR TITLE
Implement httpCaller.java 

### DIFF
--- a/src/main/java/com/example/resilience4j/external/HttpCaller.java
+++ b/src/main/java/com/example/resilience4j/external/HttpCaller.java
@@ -29,4 +29,19 @@ public class HttpCaller {
         }
         return true;
     }
+
+    /**
+     * @return true always return {@link Boolean#TRUE}
+     */
+    public boolean callExternalApiWithAlwaysSuccess() {
+        return true;
+    }
+
+    /**
+     *
+     * @throws => always throw RuntimeException
+     */
+    public boolean callExternalApiWithAlwaysFail() {
+        throw new RuntimeException("Fail to calling external api..");
+    }
 }

--- a/src/main/java/com/example/resilience4j/external/HttpCaller.java
+++ b/src/main/java/com/example/resilience4j/external/HttpCaller.java
@@ -1,7 +1,32 @@
 package com.example.resilience4j.external;
 
+import com.example.resilience4j.util.RandomValueGenerator;
+import lombok.val;
 import org.springframework.stereotype.Component;
 
 @Component(value = "externalApiCaller")
 public class HttpCaller {
+    private final RandomValueGenerator randomValueGenerator;
+
+    public HttpCaller(
+            RandomValueGenerator randomValueGenerator
+    ) {
+        this.randomValueGenerator = randomValueGenerator;
+    }
+    /**
+     * Now, we don't have any other dependency for calling other msa service.
+     * So, If result is true, will return and not trigger retry.
+     * But, If result if false, will throw to trigger retry w/ exponential delay.
+     *
+     * @throws RuntimeException when result is false
+     * @return boolean
+     */
+    public boolean callExternalApi() {
+        val result = (boolean) randomValueGenerator.generate();
+
+        if(!result) {
+            throw new RuntimeException("Fail to calling external api..");
+        }
+        return true;
+    }
 }

--- a/src/main/java/com/example/resilience4j/util/RandomBooleanGenerator.java
+++ b/src/main/java/com/example/resilience4j/util/RandomBooleanGenerator.java
@@ -1,0 +1,13 @@
+package com.example.resilience4j.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+public class RandomBooleanGenerator implements RandomValueGenerator<Boolean> {
+    @Override
+    public Boolean generate() {
+        return new Random().nextBoolean();
+    }
+}

--- a/src/main/java/com/example/resilience4j/util/RandomValueGenerator.java
+++ b/src/main/java/com/example/resilience4j/util/RandomValueGenerator.java
@@ -1,0 +1,7 @@
+package com.example.resilience4j.util;
+
+import java.util.Random;
+
+public interface RandomValueGenerator<T> {
+    public T generate();
+}

--- a/src/test/java/com/example/resilience4j/external/HttpCallerTest.java
+++ b/src/test/java/com/example/resilience4j/external/HttpCallerTest.java
@@ -7,7 +7,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -26,10 +25,20 @@ public class HttpCallerTest {
         assertTrue(httpCaller.callExternalApi());
     }
 
-    @Test
+    @Test(expected = RuntimeException.class)
     public void fail() {
         when(generator.generate()).thenReturn(false);
 
-        assertThatExceptionOfType(RuntimeException.class);
+        httpCaller.callExternalApi();
+    }
+
+    @Test
+    public void never_fail() {
+        assertTrue(httpCaller.callExternalApiWithAlwaysSuccess());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void never_success() {
+        httpCaller.callExternalApiWithAlwaysFail();
     }
 }

--- a/src/test/java/com/example/resilience4j/external/HttpCallerTest.java
+++ b/src/test/java/com/example/resilience4j/external/HttpCallerTest.java
@@ -1,7 +1,35 @@
 package com.example.resilience4j.external;
 
-import static org.junit.Assert.*;
+import com.example.resilience4j.util.RandomBooleanGenerator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
 public class HttpCallerTest {
+    @Mock
+    private RandomBooleanGenerator generator;
 
+    @InjectMocks
+    private HttpCaller httpCaller;
+
+    @Test
+    public void success() {
+        when(generator.generate()).thenReturn(true);
+
+        assertTrue(httpCaller.callExternalApi());
+    }
+
+    @Test
+    public void fail() {
+        when(generator.generate()).thenReturn(false);
+
+        assertThatExceptionOfType(RuntimeException.class);
+    }
 }


### PR DESCRIPTION
mocking the result of httpCaller w/ random generator.

Now, we don't have any other dependency for calling other msa service.
So, If result is `true`, will return and not trigger retry.
But, If result if `false`, will throw to trigger retry w/ exponential delay.